### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 The easiest way to prepare, play, and remove sounds in your Swift app!
 
 ##Installation
-###Cocoapods Installation
+###CocoaPods Installation
 Chirp is available on CocoaPods. Just add the following to your project Podfile:
 
 ```
 pod 'Chirp', '~> 1.1'
 ```
 
-###Non-Cocoapods Installation
+###Non-CocoaPods Installation
 You can drop Chirp.swift directly into your project, or drag the Chirp project into your workspace.
 
 ### Sample code


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
